### PR TITLE
Add generic `Get[T]()` method, add recursive `Fill` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # godi (Golang Dependency Injection Library)
 
+A simple dependency injection library inspired by [golobby](https://github.com/golobby/container)
+
 ## `Singletons` vs `Instances` providers
 
 Singleton providers will be executed once and the resulting instance will be shared between all injections. These are ideal for stateless and/or threadsafe constructs. Singleton providers are evaluated _lazily_ which means the provider is not called until the moment of injection.
 
 Instance providers will be executed for each injection and the resulting instances will not shared between injections. These are ideal for stateful or non-threadsafe constructs that should not be shared.
 
-## `Resolve` example:
+## `Get` example:
 
 Here we register a singleton provider (called once and the value is shared) to resolve an interface to it's provided the concrete value.
 
@@ -21,30 +23,56 @@ injector.Singleton(func () MyServiceInterface {
     return &myServiceImpl{}
 })
 
-// resolve the interace to its concrete type
-var myService MyServiceInterface
-injector.Resolve(&myService)
-```
+// resolve the interface to its concrete type
+myService := di.Get[MyServiceInterface](injector)
 
-## `NamedResolve` example:
-
-Here we register a singleton provider (called once and the value is shared) under a particular key to resolve an interface to it's provided the concrete value.
-
-*Note*: the return value of the provider and the argument type passed to `Resolve` must match.
-*Note*: arguments to `NamedResolve` _must_ be passed by reference (including interfaces and pointers)
-
-```go
 // you can register providers under string keys
-injector.NamedSingleton("mocked", func () MyServiceInterface {
-    return &myMockedServiceImpl{}
+injector.NamedSingleton("a", func () MyServiceInterface {
+    return &ServiceImplA{}
+})
+injector.NamedSingleton("b", func () MyServiceInterface {
+    return &ServiceImplB{}
 })
 
 // and resolve from these keys
-var myMockedService MyServiceInterface
-injector.NamedResolve("mocked", &myMockedService)
+aService := di.Get[MyServiceInterface](injector, "a")
+bService := di.Get[MyServiceInterface](injector, "b")
 ```
 
-## `Fill` example:
+## `Resolve` / `NamedResolve` examples:
+
+Here we register a singleton provider (called once and the value is shared) to resolve an interface to it's provided the concrete value.
+
+*Note*: the return value of the provider and the argument type passed to `Resolve` must match.
+*Note*: arguments to `Resolve` / `NamedResolve` _must_ be passed by reference (including interfaces and pointers)
+
+```go
+injector := di.NewInjector() // or di.GlobalInjector
+
+// register a "singleton" provider
+injector.Singleton(func () MyServiceInterface {
+    return &myServiceImpl{}
+})
+
+// resolve the interface to its concrete type
+var myService MyServiceInterface
+injector.Resolve(&myService)
+
+// you can register providers under string keys
+injector.NamedSingleton("a", func () MyServiceInterface {
+    return &ServiceImplA{}
+})
+injector.NamedSingleton("b", func () MyServiceInterface {
+    return &ServiceImplB{}
+})
+
+// and resolve from these keys
+var aService, bService MyServiceInterface
+injector.NamedResolve("a", &aService)
+injector.NamedResolve("b", &bService)
+```
+
+## `Fill` examples:
 
 Here we register an "instance" provider (called for each dependency, all values are unique) and use it to "fill" fields of an parent struct based on type.
 
@@ -85,21 +113,12 @@ myStruct := &MyStruct{}
 injector.Fill(myStruct)
 fmt.Println(myStruct.nested.val) // "42"
 fmt.Println(myStruct.value.val) // "12"
-```
 
-## `NamedFill` example:
-
-Here we register two "instance" providers (called for each dependency, all values are unique) under unique keys and use it to "fill" fields of an parent struct based on field name.
-
-*Note*: the return value of the provider and the tagged fields must match.
-*Note*: structs may be passed as pointers or references of pointers.
-
-```go
 
 // we can can also fill by name:
 type MyOtherStruct struct {
-    a *NestedType `di:"type"`
-    b *NestedType `di:"type"`
+    a *NestedType `di:"name"`
+    b *NestedType `di:"name"`
 }
 
 injector.NamedInstance("a", func () *NestedType {
@@ -143,7 +162,7 @@ Do not register providers via `Singleton`, `NamedSingleton`, `Instance`, and `Na
 
 The `Fill` or `Resolve` or `Call` methods _read_ from a map of bindings, and the `Singleton`, `NamedSingleton`, `Instance`, and `NamedInstace` methods _write_ to that map of bindings.
 
-This shouldn't every really happen, since you would always want to define all your providers sequentially at the startup of an application.
+This shouldn't every really happen, since you would always want to define all your providers sequentially at the startup of an application before use.
 
 Everything else is threadsafe and can be called across goroutines.
 
@@ -153,14 +172,10 @@ Verbose debug logs can be enabled / disabled and can be useful when debugging in
 
 Ex.
 ```go
-func NewSomething(injector *di.Injector) *Something {
-    injector.EnableDebugLogging()            // <-- add this in if you are dealing
-    defer injector.DisableDebugLogging()     //     with some tricky di errors
+injector.EnableDebugLogging()            // <-- add this in if you are dealing with some tricky di errors
+defer injector.DisableDebugLogging()
 
-    s := &Something{}
-    injector.Fill(s)
-    return s
-}
+s:= injector.Get[*Something]()
 ```
 
 As the logs are _very_ verbose, it is recommended that the enable / disable calls be scoped as tightly to the source of error as possible.
@@ -179,29 +194,7 @@ injector.SetErrorHandler(func (err error) {
 
 A injection error should be considered "fatal" and should be resolved in development / QA. They are not events to be handeld gracefully in production.
 
-## Future Work:
-
-## Auto-filling returned values and removing manual injection.
-
-One option is to remove the need to call `Fill` at all. Instead we could make it a private method, and automatically call it on every return value from a provider.
-
-Pros:
-    - less boilerplate calls to `Fill` in providers / constructors
-    - no need to pass `*di.Injector` around to fill things
-Cons:
-    - More implicit "magical" behavior
-    - Can no longer support returning "value" types, since internally we cannot discern the type of a `&interface{}`
-
-## The introduction of generics could provide a much cleaner interface for instantiating types:
-
-Both `Resolve` and `Fill` could be replaced with a single:
-
-```go
-value := injector.Get[SomeType]()
-```
-
-`di.Injector.Get` would automatically `Resolve` any interface type registered via a provider, and would instantiate and `Fill` any struct / pointer type.
-
 ## Acknowledgements
 
-A huge thank you to [Kevin Birke](https://github.com/kbirk) for the design and contributions to this repo.
+- A huge thank you to [Kevin Birk](https://github.com/kbirk) for the design and contributions to this repo.
+- Thanks to [golobby](https://github.com/golobby/container) for inspiring this repo and serving as a code reference for how to use the `reflect` package to accomplish sane dependency injection in go.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple dependency injection library inspired by [golobby](https://github.com/golobby/container)
 
+## Requirements
+
+`godi` requires go version 1.22 because it uses the newly added `reflect.TypeFor[T]`.
+
 ## `Singletons` vs `Instances` providers
 
 Singleton providers will be executed once and the resulting instance will be shared between all injections. These are ideal for stateless and/or threadsafe constructs. Singleton providers are evaluated _lazily_ which means the provider is not called until the moment of injection.

--- a/pkg/global.go
+++ b/pkg/global.go
@@ -1,30 +1,10 @@
-// MIT License
-
-// Copyright (c) 2019 GoLobby
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-// original source code: github.com/golobby/container
-
 package di
 
-import "log"
+import (
+	"fmt"
+	"log"
+	"reflect"
+)
 
 // GlobalInjector is the global repository of bindings
 var GlobalInjector = NewInjector()
@@ -97,4 +77,22 @@ func NamedResolve(abstraction interface{}, name string) {
 // Fill takes a struct and resolves the fields with the tag `container:"inject"`
 func Fill(receiver interface{}) {
 	GlobalInjector.Fill(receiver)
+}
+
+func Get[Type any](i *Injector) Type {
+	defer func() {
+		if r := recover(); r != nil {
+			i.handleError(fmt.Errorf("unable to resolve %s, returning empty value", reflect.TypeFor[Type]().String()))
+		}
+	}()
+	return i.Get(reflect.TypeFor[Type](), "").(Type)
+}
+
+func NamedGet[Type any](i *Injector, name string) Type {
+	defer func() {
+		if r := recover(); r != nil {
+			i.handleError(fmt.Errorf("unable to resolve %s, returning empty value", reflect.TypeFor[Type]().String()))
+		}
+	}()
+	return i.Get(reflect.TypeFor[Type](), name).(Type)
 }

--- a/pkg/injector.go
+++ b/pkg/injector.go
@@ -220,17 +220,11 @@ func (injector *Injector) Get(typ reflect.Type, name string) interface{} {
 		return nil
 	}
 
-	fmt.Println("GETTING!")
-	// if typ.Kind() == reflect.Ptr {
-	fmt.Println("FILLING")
 	err = injector.fill(instance)
 	if err != nil {
-		fmt.Println("derp")
 		injector.handleError(err)
 		return nil
 	}
-	// }
-	fmt.Println("DONE?")
 
 	return instance
 }
@@ -494,6 +488,13 @@ func (injector *Injector) Resolve(abstraction interface{}) {
 	err := injector.resolve(abstraction, "")
 	if err != nil {
 		injector.handleError(err)
+		return
+	}
+
+	err = injector.fill(abstraction)
+	if err != nil {
+		injector.handleError(err)
+		return
 	}
 }
 
@@ -506,6 +507,13 @@ func (injector *Injector) NamedResolve(abstraction interface{}, name string) {
 	err := injector.resolve(abstraction, name)
 	if err != nil {
 		injector.handleError(err)
+		return
+	}
+
+	err = injector.fill(abstraction)
+	if err != nil {
+		injector.handleError(err)
+		return
 	}
 }
 
@@ -583,6 +591,8 @@ func (injector *Injector) fill(structure interface{}) error {
 				return injector.errorMiddleWare(fmt.Errorf("argument `%+v` of type `%s` is not a struct", structure, fullyQualifiedTypeString(receiverType)))
 			}
 			s = reflect.ValueOf(structure).Elem().Elem()
+		} else if elem.Kind() == reflect.Interface {
+			s = reflect.ValueOf(structure).Elem().Elem().Elem()
 		} else {
 			return injector.errorMiddleWare(fmt.Errorf("argument of `%+v` of type `%s` is not a struct", structure, fullyQualifiedTypeString(receiverType)))
 		}

--- a/pkg/injector_test.go
+++ b/pkg/injector_test.go
@@ -139,6 +139,19 @@ func TestInjector_Singleton_Fail(t *testing.T) {
 	injector.Call(func(t *TypeC) {})
 	assert.Equal(t, 7, errorCount)
 }
+func TestInjector_Singleton_Fill(t *testing.T) {
+	var injector = NewInjector()
+	injector.SetErrorHandler(func(err error) {
+		assert.NoError(t, err)
+	})
+	injector.Singleton(func() Shape {
+		return &Circle{a: 13}
+	})
+
+	var sh Shape
+	injector.Resolve(&sh)
+	assert.Equal(t, 13, sh.GetArea())
+}
 
 func TestInjector_NamedSingleton(t *testing.T) {
 	var injector = NewInjector()
@@ -272,9 +285,6 @@ func TestInjector_Instance(t *testing.T) {
 
 func TestInjector_Instance_With_Resolve_That_Returns_Error(t *testing.T) {
 	var injector = NewInjector()
-	injector.SetErrorHandler(func(err error) {
-		assert.NoError(t, err)
-	})
 	injector.Instance(func() (Shape, error) {
 		return nil, errors.New("test error")
 	})

--- a/pkg/injector_test.go
+++ b/pkg/injector_test.go
@@ -1,26 +1,3 @@
-// MIT License
-
-// Copyright (c) 2019 GoLobby
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-// original source code: github.com/golobby/container
 package di
 
 import (
@@ -121,6 +98,21 @@ func TestInjector_Singleton(t *testing.T) {
 	injector.Call(func(db Database) {
 		assert.Equal(t, true, wasCalled)
 	})
+
+	shape := Get[Shape](injector)
+	assert.NotNil(t, shape)
+	assert.Equal(t, 42, shape.GetArea())
+
+	ta := Get[*TypeA](injector)
+	assert.NotNil(t, ta)
+	assert.NotNil(t, ta.b)
+
+	// should handle nil return values without a panic
+	injector.SetErrorHandler(func(err error) {
+		fmt.Println(err.Error())
+		assert.Error(t, err)
+	})
+	Get[TypeA](injector)
 }
 
 func TestInjector_Singleton_Fail(t *testing.T) {
@@ -160,6 +152,64 @@ func TestInjector_NamedSingleton(t *testing.T) {
 	var sh Shape
 	injector.NamedResolve(&sh, "theCircle")
 	assert.Equal(t, 13, sh.GetArea())
+}
+
+type IParent interface {
+	GetA() *A
+}
+
+type Parent struct {
+	A *A `di:"type"`
+}
+
+func (a *Parent) GetA() *A {
+	return a.A
+}
+
+type A struct {
+	B *B `di:"type"`
+}
+
+type B struct {
+	C *C `di:"type"`
+}
+
+type C struct {
+	Val int
+}
+
+func TestInjector_FillRecursively(t *testing.T) {
+	var injector = NewInjector()
+	injector.SetErrorHandler(func(err error) {
+		assert.NoError(t, err)
+	})
+	injector.Singleton(func() IParent {
+		return &Parent{}
+	})
+	injector.Singleton(func() *A {
+		return &A{}
+	})
+	injector.Singleton(func() *B {
+		return &B{}
+	})
+	injector.Singleton(func() *C {
+		return &C{
+			Val: 123,
+		}
+	})
+
+	p := Get[IParent](injector)
+	assert.NotNil(t, p)
+	assert.NotNil(t, p.GetA())
+	assert.NotNil(t, p.GetA().B)
+	assert.NotNil(t, p.GetA().B.C)
+	assert.Equal(t, 123, p.GetA().B.C.Val)
+
+	a := Get[*A](injector)
+	assert.NotNil(t, a)
+	assert.NotNil(t, a.B)
+	assert.NotNil(t, a.B.C)
+	assert.Equal(t, 123, a.B.C.Val)
 }
 
 func TestInjector_Instance(t *testing.T) {
@@ -387,6 +437,13 @@ func TestInjector_Resolve_With_UnBounded_Reference_It_Should_Fail(t *testing.T) 
 	injector.Resolve(&s)
 }
 
+type SomeStruct struct {
+	S Shape    `di:"type"`
+	D Database `di:"type"`
+	C Shape    `di:"name"`
+	X string
+}
+
 func TestInjector_Fill_With_Struct_Pointer(t *testing.T) {
 	var injector = NewInjector()
 	injector.SetErrorHandler(func(err error) {
@@ -404,6 +461,10 @@ func TestInjector_Fill_With_Struct_Pointer(t *testing.T) {
 		return &MySQL{}
 	})
 
+	injector.Singleton(func() *SomeStruct {
+		return &SomeStruct{}
+	})
+
 	myApp := struct {
 		S Shape    `di:"type"`
 		D Database `di:"type"`
@@ -415,6 +476,12 @@ func TestInjector_Fill_With_Struct_Pointer(t *testing.T) {
 
 	assert.IsType(t, &Circle{}, myApp.S)
 	assert.IsType(t, &MySQL{}, myApp.D)
+
+	someStruct := Get[*SomeStruct](injector)
+	assert.IsType(t, &Circle{}, someStruct.S)
+	assert.IsType(t, &MySQL{}, someStruct.D)
+	assert.IsType(t, &Circle{}, someStruct.C)
+	assert.Equal(t, 5, someStruct.C.GetArea())
 
 }
 


### PR DESCRIPTION
These were the two `TODOs` in the README. :)

The first is to add direct instantiation support with generics:
```go
injector.Singleton(func() (Shape, error) {
    return &Circle{Radius: 42}, nil
})

v := di.Get[Shape](injector)
```

The second is to support filling hierarchical objects using recursion in the `Fill` logic:

```go
type A struct {
	B *B `di:"type"`
}
type B struct {
	C *C `di:"type"`
}
type C struct {
	Val int
}

injector.Singleton(func() *A {
    return &A{}
})
injector.Singleton(func() *B {
    return &B{}
})
injector.Singleton(func() *C {
    return &C{
	Val: 123,
    }
})

a := di.Get[*A](injector)
fmt.Println(a.B.C.Val) // 123
```
