### PR TITLE
Fix circular dependency issues. Fix instances being "filled" multiple times

### DIFF
--- a/pkg/global.go
+++ b/pkg/global.go
@@ -79,20 +79,32 @@ func Fill(receiver interface{}) {
 	GlobalInjector.Fill(receiver)
 }
 
+// Get takes a pointer or interface type argument and returns the provided implemenation.
 func Get[Type any](i *Injector) Type {
 	defer func() {
 		if r := recover(); r != nil {
 			i.handleError(fmt.Errorf("unable to resolve %s, returning empty value", reflect.TypeFor[Type]().String()))
 		}
 	}()
-	return i.Get(reflect.TypeFor[Type](), "").(Type)
+
+	if reflect.TypeFor[Type]().Kind() != reflect.Interface && reflect.TypeFor[Type]().Kind() != reflect.Ptr {
+		i.handleError(fmt.Errorf("unable to resolve %s, type must be either a pointer or an interface, not: %s", reflect.TypeFor[Type]().String(), reflect.TypeFor[Type]().Kind()))
+	}
+
+	return i.get(reflect.TypeFor[Type](), "").(Type)
 }
 
+// NamedGet takes a pointer or interface type argument and a name string and returns the provided implemenation.
 func NamedGet[Type any](i *Injector, name string) Type {
 	defer func() {
 		if r := recover(); r != nil {
 			i.handleError(fmt.Errorf("unable to resolve %s, returning empty value", reflect.TypeFor[Type]().String()))
 		}
 	}()
-	return i.Get(reflect.TypeFor[Type](), name).(Type)
+
+	if reflect.TypeFor[Type]().Kind() != reflect.Interface && reflect.TypeFor[Type]().Kind() != reflect.Ptr {
+		i.handleError(fmt.Errorf("unable to resolve %s, type must be either a pointer or an interface, not: %s", reflect.TypeFor[Type]().String(), reflect.TypeFor[Type]().Kind()))
+	}
+
+	return i.get(reflect.TypeFor[Type](), name).(Type)
 }


### PR DESCRIPTION
Of course I introduce the recursive filling without realizing that:

A) It was re-filling previously instantiated singleton types
B) It introduces the possibility of filling infinite cycles, deadlocking on singletons and stack overflowing on instances.

This PR fixes both of those. 

A) Singleton types will only ever be "filled" once. 
B) Injection now gracefully handles cyclical objects, in the case of instances, the values are cached each that injection so resolve them.

The only outward change is that we can no longer create provider that returns structs by value. There is no benefit in doing so, since that is what the `Instance` registration is for anyway.